### PR TITLE
Update landing request API for use in GatewayAPI demonstrations where multiple services are involved

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,11 @@ Deathstar as a Service
 
 Build a Docker container locally with `make build`.
 
-Build and push to a registry with `make publish`. You can specify the image tag with the env var `IMAGE` (defaults to `cilium/starwars`). 
+Build and push to a registry with `make publish`. You can specify the image tag with the env var `IMAGE` (defaults to `cilium/starwars`)
+
+## Set custom landing response msg
+Set the `LANDING_RESPONSE_MSG` environment variable to override default landing request response message string.
+
+## Enable landing service redirect
+Set the `LANDING_REQUEST_URL` environment variable to redirect landing request to different location. 
+ 

--- a/restapi/operations/post_request_landing_responses.go
+++ b/restapi/operations/post_request_landing_responses.go
@@ -50,3 +50,44 @@ func (o *PostRequestLandingOK) WriteResponse(rw http.ResponseWriter, producer ru
 	}
 
 }
+
+// HTTP code for type PostRequestLandingServiceUnavailable
+const PostRequestLandingServiceUnavailableCode int = 503
+
+/*PostRequestLandingServiceUnavailable Landing Request Service Not available
+
+swagger:response postRequestLandingServiceUnavailable
+*/
+type PostRequestLandingServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload string `json:"body,omitempty"`
+}
+
+// NewPostRequestLandingServiceUnavailable creates PostRequestLandingServiceUnavailable with default headers values
+func NewPostRequestLandingServiceUnavailable() *PostRequestLandingServiceUnavailable {
+	return &PostRequestLandingServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the post request landing service unavailable response
+func (o *PostRequestLandingServiceUnavailable) WithPayload(payload string) *PostRequestLandingServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the post request landing service unavailable response
+func (o *PostRequestLandingServiceUnavailable) SetPayload(payload string) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *PostRequestLandingServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	payload := o.Payload
+	if err := producer.Produce(rw, payload); err != nil {
+		panic(err) // let the recovery middleware deal with this
+	}
+}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -40,3 +40,7 @@ paths:
           description: OK
           schema:
             type: string
+        '503':
+          description: Landing Request Service Not available
+          schema:
+            type: string


### PR DESCRIPTION
This implements two features exposed as optional environment variables that helped me extend the existing starwars tutorial into more complicated demo service environments using Ingress and GatewayAPI without needing additional images.  

Here's what is implemented:
1. LANDING_RESPONSE_MSG
This environment variable allows the default landing request response to be replaced on a service backend basis.  This is very useful to communicate back to the curl client which cluster service backend you are actually talking with while making a series of changes to ingress or gatewayAPI rules as part of a guided walkthrough. 

2. LANDING_REQUEST_URL
This environment variable allows starwars image based service to call a separate landing request service URL when a landing request is made.  I used this to create thin multi-team microservice configuration involving multiple services using the same starwars image.  
 
I used these environment variables in my gateway API/ingress demos at SCALE conference, to show some 'interesting' starwars themed examples that extend the death star service example.  I'm hoping to build a documented example(s) for Cilium docs along the same lines, but first I'd like to get the official starwars service docker image updated with these optional capability so I can use the official images in the deployment manifests I write-up.