### PR TITLE
Bump Go to 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # BUILDER
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.20 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.24 as builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/cilium/starwars-docker
 
-go 1.19
+go 1.23.0
+
+toolchain go1.24.2
 
 require (
 	github.com/go-openapi/errors v0.0.0-20170104180542-fc3f73a22449

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdko
 github.com/asaskevich/govalidator v0.0.0-20170104211126-fdf19785fd35 h1:jtOyR8GH6bAopQsGgvAhTLbp2kIgGw5hJpfRoFjr6AI=
 github.com/asaskevich/govalidator v0.0.0-20170104211126-fdf19785fd35/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/go-units v0.2.1-0.20151218222130-651fc226e744 h1:p+B7C24dUeS3z38OYrWQplXkYTXO2mrpDs/ZPQTZGyc=
 github.com/docker/go-units v0.2.1-0.20151218222130-651fc226e744/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/go-openapi/analysis v0.0.0-20161231055341-d5a75b7d751c h1:2vsKPPVj/x6e21XiUr3zk+RpsNjknbEUvhVETVSY1A8=
@@ -45,6 +46,7 @@ github.com/mitchellh/mapstructure v0.0.0-20161211222315-bfdb1a85537d/go.mod h1:F
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tylerb/graceful v1.2.14-0.20170103162203-d37e108c8976 h1:xpKU6BlQNlUfVY/P70vQuOyoU1Jeza7QX16+EUxrAeI=
@@ -59,3 +61,4 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Bump to Go 1.24 and bump the minimum required version to 1.23 to match
the requirements in the dependencies (via 'go mod tidy').
